### PR TITLE
Added null-value handling for script arguments and updated properties

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -44,6 +44,27 @@ The `argumentStyle` configuration property can take following values:
 
 |====
 
+The `handleNullValues` configuration property can take the following values:
+|====
+| handleNullValues | Description | Combination with `argumentStyle` | Example where `foo` is `null`
+
+| `asEmptyString`
+| Arguments that contain a `null` value will be interpreted as an empty string.
+| `dash` | `command -foo -bar baz`
+||| `slash` | `command /foo /bar baz`
+||| `variables-bash` | `foo=''; bar='baz'; command $foo $bar`
+||| `variables-powershell` | `$foo=''; $bar='baz'; command $foo $bar`
+
+| `asGone`
+| Arguments that contain a `null` value removed from the argument list.
+| `dash` | `command -bar baz`
+||| `slash` | `command /bar baz`
+||| `variables-bash` | `bar='baz'; command $foo $bar`
+||| `variables-powershell` | `$bar='baz'; command $foo $bar`
+
+|====
+
+
 == Limitations
 
 * Only password authentication is supported, at least for now.

--- a/src/main/java/com/evolveum/polygon/connector/ssh/CommandProcessor.java
+++ b/src/main/java/com/evolveum/polygon/connector/ssh/CommandProcessor.java
@@ -62,11 +62,25 @@ public class CommandProcessor {
                 // we want this to go last
                 continue;
             }
-            commandLineBuilder.append(" ");
-            commandLineBuilder.append(paramPrefix).append(argEntry.getKey());
-            if (argEntry.getValue() != null) {
+            Object value = argEntry.getValue();
+            boolean insertAttribute = true;
+            if(value == null) {
+                switch (configuration.getHandleNullValues()) {
+                    case SshConfiguration.HANDLE_NULL_AS_EMPTY_STRING:
+                        value = "";
+                        break;
+                    case SshConfiguration.HANDLE_NULL_AS_GONE:
+                        insertAttribute = false;
+                        break;
+                    default:
+                        throw new ConfigurationException("Unknown value of handleNullValues: " + configuration.getHandleNullValues());
+                }
+            }
+            if(insertAttribute) {
                 commandLineBuilder.append(" ");
-                commandLineBuilder.append(argEntry.getValue().toString());
+                commandLineBuilder.append(paramPrefix).append(argEntry.getKey());
+                commandLineBuilder.append(" ");
+                commandLineBuilder.append(value);
             }
         }
         if (arguments.get(null) != null) {
@@ -86,14 +100,30 @@ public class CommandProcessor {
                 // we want this to go last
                 continue;
             }
-            commandLineBuilder.append(variablePrefix).append(argEntry.getKey());
-            if (spaces) {
-                commandLineBuilder.append(" = ");
-            } else {
-                commandLineBuilder.append("=");
+            Object value = argEntry.getValue();
+            boolean insertAttribute = true;
+            if(value == null) {
+                switch (configuration.getHandleNullValues()) {
+                    case SshConfiguration.HANDLE_NULL_AS_EMPTY_STRING:
+                        value = "";
+                        break;
+                    case SshConfiguration.HANDLE_NULL_AS_GONE:
+                        insertAttribute = false;
+                        break;
+                    default:
+                        throw new ConfigurationException("Unknown value of handleNullValues: " + configuration.getHandleNullValues());
+                }
             }
-            commandLineBuilder.append(quoteSingle(argEntry.getValue().toString()));
-            commandLineBuilder.append("; ");
+            if(insertAttribute) {
+                commandLineBuilder.append(variablePrefix).append(argEntry.getKey());
+                if (spaces) {
+                    commandLineBuilder.append(" = ");
+                } else {
+                    commandLineBuilder.append("=");
+                }
+                commandLineBuilder.append(quoteSingle(value));
+                commandLineBuilder.append("; ");
+            }
         }
         commandLineBuilder.append(command);
         if (arguments.get(null) != null) {
@@ -104,9 +134,6 @@ public class CommandProcessor {
     }
 
     private String quoteSingle(Object value) {
-        if (value == null) {
-            return "";
-        }
         return "'" + value.toString().replaceAll("'", "''") + "'";
     }
 }

--- a/src/main/java/com/evolveum/polygon/connector/ssh/SshConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/ssh/SshConfiguration.java
@@ -16,9 +16,7 @@
 
 package com.evolveum.polygon.connector.ssh;
 
-import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.common.security.GuardedString;
-import org.identityconnectors.framework.common.exceptions.ConfigurationException;
 import org.identityconnectors.framework.spi.AbstractConfiguration;
 import org.identityconnectors.framework.spi.ConfigurationProperty;
 
@@ -84,6 +82,15 @@ public class SshConfiguration extends AbstractConfiguration {
     // fu='foo'; bar='baz'; command $foo $bar
     public static final String ARGUMENT_STYLE_VARIABLES_BASH = "variables-bash";
 
+    /**
+     * Defines how to handle NULL value arguments.
+     * If a script argument is NULL, it can be inserted as an empty string ("asEmpty") or it can be removed from the argument list ("asGone").
+     */
+    private String handleNullValues = HANDLE_NULL_AS_GONE;
+
+    public static final String HANDLE_NULL_AS_EMPTY_STRING = "asEmptyString";
+    public static final String HANDLE_NULL_AS_GONE = "asGone";
+
     @ConfigurationProperty(order = 100)
     public String getHost() {
         return host;
@@ -136,6 +143,15 @@ public class SshConfiguration extends AbstractConfiguration {
 
     public void setArgumentStyle(String argumentStyle) {
         this.argumentStyle = argumentStyle;
+    }
+
+    @ConfigurationProperty(order = 130)
+    public String getHandleNullValues() {
+        return handleNullValues;
+    }
+
+    public void setHandleNullValues(String handleNullValues) {
+        this.handleNullValues = handleNullValues;
     }
 
     @Override

--- a/src/main/resources/com/evolveum/polygon/connector/ssh/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ssh/Messages.properties
@@ -14,190 +14,23 @@
 # limitations under the License.
 #
 
-connector.ldap.display=LDAP Connector
-
 host.display=Host
-host.help=The name or IP address of the LDAP server host.
+host.help=The name or IP address of the SSH server host.
 
-port.display=Port number
-port.help=LDAP server port number.
+username.display=Username
+username.help=The username to login at the SSH server.
 
-connectionSecurity.display=Connection security
-connectionSecurity.help=Method to use to secure connection to the LDAP server. Values: "ssl", "starttls"
+password.display=Password
+password.help=The password for the login username.
 
-sslProtocol.display=SSL protocol
-sslProtocol.help=The standard name of the SSL protocol. This name is used to instantiate javax.net.ssl.SSLContext. See the SSLContext section in the Java Cryptography Architecture Standard Algorithm Name Documentation. E.g. SSL, SSLv2, SSLv3, TLS, TLSv1, TLSv1.1, TLSv1.2
+authenticationScheme.display=Authentication Scheme
+authenticationScheme.help=The authentication scheme defines the login method and can be "password" or "publicKey".
 
-enabledSecurityProtocols.display=Enabled security protocols
-enabledSecurityProtocols.help=Set of security protocols that are acceptable for protocol negotiation. This name is used to set up SSLEngine. See the SSLContext section in the Java Cryptography Architecture Standard Algorithm Name Documentation. E.g. SSL, SSLv2, SSLv3, TLS, TLSv1, TLSv1.1, TLSv1.2
+knownHosts.display=Known Hosts
+knownHosts.help=Entries in the "known_hosts" file format, that this connector can trust. If it is empty, the connector accepts any hosts.
 
-enabledCipherSuites.display=Enabled cipher suites
-enabledCipherSuites.help=
+argumentStyle.display=Argument Style
+argumentStyle.help=The style in which the script arguments are formatted. It can be "dash", "slash", "variables-powershell" or "variables-bash".
 
-allowUntrustedSsl.display=Allow untrusted SSL/TLS
-allowUntrustedSsl.help=If set to false (which is default and recommended), connector checks server certificate validity in SSL/TLS mode against system default truststore (e.g. Java cacerts). If set to true, connector does not check server certificate validity - do not use this option in the production environment.
-
-authenticationType.display=Authentication type
-authenticationType.help=The authentication mechanism to use. Values: "simple", "SASL-GSSAPI"
-
-bindDn.display=Bind DN
-bindDn.help=The DN to use when binding to the LDAP server
-
-bindPassword.display=Bind password
-bindPassword.help=Password to use when binding to the LDAP server
-
-connectTimeout.display=Connect timeout
-connectTimeout.help=Timeout for LDAP server connection (in milliseconds)
-
-maximumNumberOfAttempts.display=Maximum number of attempts
-maximumNumberOfAttempts.help=Maximum number of attempts to retrieve the entry or to re-try the operation. This number is applicable in replicated topology when handling connection failures and re-trying on another server, when following referrals and in similar situations.
-
-baseContext.display=Base context
-baseContext.help=The base DN used when no explicit base DN is specified
-
-servers.display=Servers
-servers.help=Structured definition of a server in the directory topology. It contains attribute-value pairs that define each individual server. The names of configuration properties can be used, separated by equal signs and semicolons, such as this: baseContext=dc=sub,dc=example,dc=com; host=sub.example.com; port=389  The server will be selected for each operation according to the baseContext that is specified in server definition. The most specific DN match will be used. If there are more multiple servers specified for the same baseContext then one of them will be selected randomly. The server which does not specify any baseContext is considered to be the default and that server will be used if the DN cannot be matched. This is equivalent to the server which is specified by ordinary configuration properties.  The configuration properties that are not explicitly specified in the server configuration line are taken from the ordinary configuration.
-
-referralStrategy.display=Referral stratery
-referralStrategy.help=Strategy of referral resolution. Values: "follow", "ignore", "throw"
-
-passwordAttribute.display=Password attribute
-passwordAttribute.help=Name of the LDAP attribute that is used to store account password
-
-passwordHashAlgorithm.display=Password hash algorithm
-passwordHashAlgorithm.help=Hash the passwords with a specified algorithm before they are sent to the server.
-
-passwordReadStrategy.display=Password read strategy
-passwordReadStrategy.help=Strategy for reading the password. LDAP schema itself cannot reliably indicate whether a password is readable or not. Therefore there this can be configured. Possible values: "unreadable": Password is not readable, it is never returned by the connector. This is the default. "incompleteRead": If password is returned by the LDAP server then connector will remove the value. Connector will indicate that the value is incomplete. Therefore IDM system can learn that there is password without knowing the password value. "readable": If password is returned by the LDAP server then it is passed to the IDM system in the same form as it was returned.
-
-pagingStrategy.display=Paging strategy
-pagingStrategy.help=Strategy used to send search requests that require paging. Usually specified preference over mechanisms such as VLV or simple paged results. Values: "none", "auto", "spr", "vlv"
-
-pagingBlockSize.display=Paging block size
-pagingBlockSize.help=Number of entries in one paging block. Used as a default value when page size is not explicitly specified in the request.
-
-vlvSortAttribute.display=VLV sort attribute
-vlvSortAttribute.help=Name of LDAP attribute used to sort the results if VLV is used for paging and no explicit sorting attribute is specified in the request.
-
-vlvSortOrderingRule.display=VLV ordering rule
-vlvSortOrderingRule.help=LDAP ordering rule to use in VLV requests. Some LDAP servers require explicit specification of ordering rule.
-
-uidAttribute.display=Primary identifier attribute
-uidAttribute.help=Name of LDAP attribute to use as a primary identifier. This will be used as ConnId __UID__ attribute. The default is entryUUID which is the best choice for modern LDAP servers. Value of "dn" can be used here to use entry DN as a primary identifier.
-
-operationalAttributes.display=Operational attributes
-operationalAttributes.help=Names of significant LDAP operational attributes. Connector will try to return these attributes in each entry.
-
-readSchema.display=Read schema
-readSchema.help=If set to true (which is the default) then the connector will try to read LDAP schema.
-
-schemaQuirksMode.display=Schema quirks mode
-schemaQuirksMode.help=Some LDAP servers use strange or non-standard variations of schema definition. The quirks mode is used to tolerate these variations and use as much of the schema definition as possible.
-
-allowUnknownAttributes.display=Allow unknown attributes
-allowUnknownAttributes.help=Accept also attributes that are not defined in schema. Single-value string is assumed as the attribute type.
-
-usePermissiveModify.display=Use permissive modify
-usePermissiveModify.help=Use permissive modify LDAP control for modify operations. Possible values: "never", "auto", "always". Default value: auto
-
-synchronizationStrategy.display=Synchronization strategy
-synchronizationStrategy.help=Strategy to use for almost-real-time synchronization. Values: "none", "auto", "sunChangeLog", "modifyTimestamp", "openLdapAccessLog"
-
-baseContextsToSynchronize.display=Base contexts to synchronize
-baseContextsToSynchronize.help=List of base contexts DNs that will be accepted during synchronization. If set to empty then all DNs will be accepted.
-
-objectClassesToSynchronize.display=Object classes to synchronize
-objectClassesToSynchronize.help=List of object classes that will be accepted during synchronization. If set to empty then all object classes will be accepted.
-
-attributesToSynchronize.display=Attributes to synchronize
-attributesToSynchronize.help=List of attributes that will be passed during synchronization. If set to empty then all non-operational attributes will be passed.
-
-modifiersNamesToFilterOut.display=Modifiers names to filter out
-modifiersNamesToFilterOut.help=List of modifiers DNs that will NOT be accepted during synchronization.
-
-changeLogBlockSize.display=Changelog block size
-changeLogBlockSize.help=Number of change log entries to fetch in a single request.
-
-changeNumberAttribute.display=Change number attribute
-changeNumberAttribute.help="Change number" attribute - unique indentifier of the change in the change log.
-
-useUnsafeNameHint.display=Use unsafe name hint
-useUnsafeNameHint.help=Entry DN can be provided to the connector as a "name hint". Connector will use the name hint whenever it can use it safely. But there are some cases when the name hint cannot be used safely. There are mostly modify and delete operations when in a rare case a wrong object can be modified or deleted. The connector will not use the name hint in these cases by default. It will make explicit search to make sure that everything is fair and square before attempting the operation. However this comes at the expense of performance. If this switch is set to true then the connector will try to use the name hint even if it is not completely safe. This may mean significant perfomacne boost for modify and delete operations.
-
-enableExtraTests.display=Enable extra tests
-enableExtraTests.help=Enable extra tests during the test connection operations. Those tests may take longer and they may make more LDAP requests. These tests try to test some tricky situations and border conditions and they are generally useful only for connector developers or when diagnosing connector bugs.
-
-timestampPresentation.display=Timestamp presentation
-timestampPresentation.help=Timestamp presentation mode. This controls the way how connector presents the timestamps to the client. It can present them as unix epoch (number of seconds since 1970) or the timestamps can be presented in LDAP-native string form (ISO 8601). Possible values: "unixEpoch", "string", default value: "unixEpoch"
-
-includeObjectClassFilter.display=Include objectClass filter
-includeObjectClassFilter.help=Enables inclusion of explicit object class filter in all searches. Normally the connector would derive search filter only based on the attributes specified in the query. E.g. (&(uid=foo)(cn=bar)). If includeObjectClassFilter is set to true, then also explicit filter for objectclass will be included. E.g (&(objectClass=inetOrgPerson)(uid=foo)(cn=bar))
-
-alternativeObjectClassDetection.display=Alternative object class detection
-alternativeObjectClassDetection.help=Enabled more tolerant algorithm to detect which object class is structural and which is auxiliary.
-
-structuralObjectClassesToAuxiliary.display=Structural object classes to auxiliary
-structuralObjectClassesToAuxiliary.help=If set to true, adds all additional structural object classes without children to the auxiliary object classes list on the connector.
-
-additionalSearchFilter.display=Additional search filter
-additionalSearchFilter.help=Search filter that will be added to all search operations that the connector does.
-
-defaultSearchScope.display=Default search scope
-defaultSearchScope.help=Default search scope used for ordinary searches. Possible values: "sub", "one". Default value: sub
-
-# LDAP
-
-lockoutStrategy.display=Lockout strategy
-lockoutStrategy.help=Specifies strategy of handling account lockouts. Please note that the "openldap" lockout strategy is EXPERIMENTAL. Possible values: "none", "openldap". Default value: "none".
-
-openLdapAccessLogDn.display=OpenLDAP access log DN 
-openLdapAccessLogDn.help=The DN of the OpenLDAP access log in your LDAP-server
-
-openLdapAccessLogAdditionalFilter.display=OpenLDAP access log additional search filter
-openLdapAccessLogAdditionalFilter.help=An additional search filter for the delete events in the access log. Basic filter is '(&(objectClass=auditDelete)(reqResult=0)(reqStart>=<timestamp>))'
-
-languageTagAttributes.display=Language tag attributes
-languageTagAttributes.help=Attribute that supports language tag (RFC 3866). EXPERIMENTAL. Not officially supported. Use at your own risk only.
-
-tolerateMultivalueReduction.display=Tolerate multivalue reduction
-tolerateMultivalueReduction.help=If tolerateMultivalueReduction is set to true, then the connector will discard all the extra values of multivalue attributes that are reduced to single value. EXPERIMENTAL. Not officially supported. Use at your own risk only.
-
-# AD & eDir
-
-userObjectClass.display=User object class
-userObjectClass.help=Object class to use for user accounts.
-
-groupObjectClass.display=Group object class
-groupObjectClass.help=Object class to use for groups.
-
-groupObjectMemberAttribute.display=Group member attribute
-groupObjectMemberAttribute.help=Group member attribute name.
-
-# AD
-
-globalCatalogServers.display=Global catalog servers
-globalCatalogServers.help=Specification of global catalog servers. If left empty then the connector will try to determine the host and port automatically. The definition has the same format as "servers" definition.
-
-globalCatalogStrategy.display=Global catalog strategy
-globalCatalogStrategy.help=Strategy of global catalog usage. none: Do not use global catalog explicitly. The global catalog will only be used when following the referrals. resolve: The global catalog will be used to resolve DNs. Only the attributes that are stored in global catalog will be returned when object is retrieved. This provides incomplete data, but it avoids additional round-trip to an authoritative server. read:  The global catalog will be used to resolve DNs. Only the attribute that are stored in global catalog will be returned when object is retrieved. This provides incomplete data, but it avoids additional round-trip to an authoritative server.
-
-allowBruteForceSearch.display=Allow brute force search
-allowBruteForceSearch.help=If set to true then the connector will try to search all defined servers for an entry if all other attempts fail.
-
-rawUserAccountControlAttribute.display=Raw userAccountControl
-rawUserAccountControlAttribute.help=If set to false then the connector will interpret the content of userAccountControl attribute and will decompose it to pseudo-attributes for enabled state, lockout, etc. If set to true then the connector will NOT do any interpretation and the userAccountControl will be exposed as a simple attribute.
-
-nativeAdSchema.display=Native AD schema
-nativeAdSchema.help=If set to true, then the connector will use native AD schema definition. If set to false, connector will use LDAP-like schema definition exposed by the AD server. Default value: false. EXPERIMENTAL. There may be subtle differences between LDAP schema and AD schema. Not completely tested yet.
-
-tweakSchema.display=Tweak schema
-tweakSchema.help=Extend the declared AD schema with tweaks that allow practical usage of the schema. AD will generally allow any attribute to be set to any object regardless for the schema. This is often used is practice. E.g. declared AD schema for users and groups does not include samAccountName attribute. But that attribute is needed for users and groups to work correctly. If this configuration property is set to true (which is the default) then the connector will artificially add these attributes to the schema.
-
-includeObjectCategoryFilter.display=Include object category filter
-includeObjectCategoryFilter.help=Enables inclusion of explicit object category filter in all searches. Normally the connector would derive search filter only based on the attributes specified in the query. E.g. (&(uid=foo)(cn=bar)). If includeObjectClassFilter is set to true, then also explicit filter for objectClass and objectCategory will be included. E.g (&(objectClass=inetOrgPerson)(objectCategory=CN=Person,CN=Schema,CN=Configuration,DC=example,DC=com)(uid=foo)(cn=bar)). Only works if includeObjectClassFilter is enabled and native AD schema is used. Default value: false. EXPERIMENTAL. Not completely tested yet.
-
-addDefaultObjectCategory.display=Add default object category
-addDefaultObjectCategory.help=If set to true then the connector will automatically add default object category to all created objects. Object category is automatically determined from schema. Only works if native AD schema is enabled. Default value: false. EXPERIMENTAL. Not completely tested yet.
-
-forcePasswordChangeAtNextLogon.display=Force password change at next log-on
-forcePasswordChangeAtNextLogon.help=If set to true then the connector will force password change at next log-on every time when the password is changed. If set to false (default) the password change at next log-on will not be forced.
+handleNullValues.display=Null-Value Handling
+handleNullValues.help=Defines how to handle null-values in arguments. It can be "asEmptyString" or "asGone".


### PR DESCRIPTION
Null values in script arguments can be handled in different ways. The handling can be configured by the option `handleNullValues` with the values `asGone` (default value) and `asEmptyString`. This allows the user to choose, if the argument should bee completely removed, or be inserted as empty string.
Also the display texts and descriptions for the different configuration properties were updated to match the existing ones.

Previously the connector threw a NullPointerException if the value of a script argument was null. This prevented the scripts from accepting empty values.