### PR TITLE
Improved port configuration and public key authentication

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -67,9 +67,6 @@ The `handleNullValues` configuration property can take the following values:
 
 == Limitations
 
-* Only password authentication is supported, at least for now.
-There is some code for public key authentication, but it is untested and probably incomplete.
-
 * Only "execution mode" of SSH is supported.
 The connector will create SSH connection, authenticate, execute the command and tear down the connection.
 This is slow, but it is reliable.

--- a/src/main/java/com/evolveum/polygon/connector/ssh/SshConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/ssh/SshConfiguration.java
@@ -49,6 +49,17 @@ public class SshConfiguration extends AbstractConfiguration {
     private GuardedString password = null;
 
     /**
+     * Private Key for public key authentication.
+     * The format is PKCS8.
+     */
+    private GuardedString privateKey = null;
+
+    /**
+     * Passphrase for public key authentication.
+     */
+    private GuardedString passphrase = null;
+
+    /**
      * Authentication scheme for the SSH connection.
      */
     private String authenticationScheme = AUTHENTICATION_SCHEME_PASSWORD;
@@ -131,6 +142,24 @@ public class SshConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(order = 104)
+    public GuardedString getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(GuardedString privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    @ConfigurationProperty(order = 105)
+    public GuardedString getPassphrase() {
+        return passphrase;
+    }
+
+    public void setPassphrase(GuardedString passphrase) {
+        this.passphrase = passphrase;
+    }
+
+    @ConfigurationProperty(order = 106)
     public String getAuthenticationScheme() {
         return authenticationScheme;
     }

--- a/src/main/java/com/evolveum/polygon/connector/ssh/SshConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/ssh/SshConfiguration.java
@@ -33,7 +33,10 @@ public class SshConfiguration extends AbstractConfiguration {
      */
     private String host;
 
-//    private int port = DEFAULT_PORT;
+    /**
+     * Server port.
+     */
+    private int port = 22;
 
     /**
      * Username of the user, used for authentication.
@@ -101,6 +104,15 @@ public class SshConfiguration extends AbstractConfiguration {
     }
 
     @ConfigurationProperty(order = 101)
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    @ConfigurationProperty(order = 102)
     public String getUsername() {
         return username;
     }
@@ -109,7 +121,7 @@ public class SshConfiguration extends AbstractConfiguration {
         this.username = username;
     }
 
-    @ConfigurationProperty(order = 102)
+    @ConfigurationProperty(order = 103)
     public GuardedString getPassword() {
         return password;
     }
@@ -118,7 +130,7 @@ public class SshConfiguration extends AbstractConfiguration {
         this.password = password;
     }
 
-    @ConfigurationProperty(order = 103)
+    @ConfigurationProperty(order = 104)
     public String getAuthenticationScheme() {
         return authenticationScheme;
     }

--- a/src/main/java/com/evolveum/polygon/connector/ssh/SshConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/ssh/SshConnector.java
@@ -80,7 +80,7 @@ public class SshConnector implements PoolableConnector, TestOp, ScriptOnResource
         ssh.addHostKeyVerifier(hostKeyVerifier);
         LOG.ok("Connecting to {0}", getConnectionDesc());
         try {
-            ssh.connect(configuration.getHost());
+            ssh.connect(configuration.getHost(), configuration.getPort());
         } catch (IOException e) {
             LOG.error("Error creating SSH connection to {0}: {1}", getHostDesc(), e.getMessage());
             throw new ConnectionFailedException("Error creating SSH connection to " + getHostDesc() + ": " + e.getMessage(), e);

--- a/src/main/java/com/evolveum/polygon/connector/ssh/SshConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/ssh/SshConnector.java
@@ -17,10 +17,6 @@
 package com.evolveum.polygon.connector.ssh;
 
 import com.evolveum.polygon.common.GuardedStringAccessor;
-import com.evolveum.polygon.common.SchemaUtil;
-import net.schmizz.sshj.Config;
-import net.schmizz.sshj.ConfigImpl;
-import net.schmizz.sshj.DefaultConfig;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.common.IOUtils;
 import net.schmizz.sshj.connection.ConnectionException;
@@ -28,11 +24,16 @@ import net.schmizz.sshj.connection.channel.direct.Session;
 import net.schmizz.sshj.transport.TransportException;
 import net.schmizz.sshj.transport.verification.HostKeyVerifier;
 import net.schmizz.sshj.userauth.UserAuthException;
-//import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import net.schmizz.sshj.userauth.keyprovider.KeyProvider;
+import net.schmizz.sshj.userauth.password.PasswordUtils;
 import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.common.security.GuardedString;
-import org.identityconnectors.framework.common.exceptions.*;
-import org.identityconnectors.framework.common.objects.*;
+import org.identityconnectors.framework.common.exceptions.ConfigurationException;
+import org.identityconnectors.framework.common.exceptions.ConnectionFailedException;
+import org.identityconnectors.framework.common.exceptions.ConnectorException;
+import org.identityconnectors.framework.common.exceptions.ConnectorIOException;
+import org.identityconnectors.framework.common.objects.OperationOptions;
+import org.identityconnectors.framework.common.objects.ScriptContext;
 import org.identityconnectors.framework.spi.Configuration;
 import org.identityconnectors.framework.spi.ConnectorClass;
 import org.identityconnectors.framework.spi.PoolableConnector;
@@ -40,11 +41,6 @@ import org.identityconnectors.framework.spi.operations.ScriptOnResourceOp;
 import org.identityconnectors.framework.spi.operations.TestOp;
 
 import java.io.IOException;
-import java.security.Security;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @ConnectorClass(displayNameKey = "connector.ssh.display", configurationClass = SshConfiguration.class)
@@ -131,12 +127,36 @@ public class SshConnector implements PoolableConnector, TestOp, ScriptOnResource
     private void authenticatePublicKey() {
         LOG.ok("Authenticating to {0} using public key authentication", getConnectionDesc());
         try {
-            ssh.authPublickey(configuration.getUsername());
+            GuardedStringAccessor privateKey = new GuardedStringAccessor();
+            GuardedStringAccessor passphrase = new GuardedStringAccessor();
+
+            if (configuration.getPrivateKey() != null) {
+                configuration.getPrivateKey().access(privateKey);
+            }
+            if (configuration.getPassphrase() != null) {
+                configuration.getPassphrase().access(passphrase);
+            }
+
+            if (privateKey.getClearChars() != null) {
+                KeyProvider keyProvider;
+                try {
+                    if (passphrase.getClearChars() != null) {
+                        keyProvider = ssh.loadKeys(privateKey.getClearString(), null, PasswordUtils.createOneOff(passphrase.getClearChars()));
+                    } else {
+                        keyProvider = ssh.loadKeys(privateKey.getClearString(), null, null);
+                    }
+                } catch (IOException e) {
+                    throw new ConfigurationException("Error parsing private key for SSH public key authentication", e);
+                }
+                ssh.authPublickey(configuration.getUsername(), keyProvider);
+            } else {
+                ssh.authPublickey(configuration.getUsername());
+            }
         } catch (UserAuthException e) {
-            LOG.error("SSH public key authentication as {0} to {1} failed: {2}", configuration.getUsername(), getHostDesc(), e.getMessage());
+            LOG.error(e, "SSH public key authentication as {0} to {1} failed: {2}", configuration.getUsername(), getHostDesc(), e.getMessage());
             throw new ConnectionFailedException("SSH public key authentication as "+configuration.getUsername()+" to "+getHostDesc()+" failed: " + e.getMessage(), e);
         } catch (TransportException e) {
-            LOG.error("Communication error during SSH public key authentication as {0} to {1} failed: {2}", configuration.getUsername(), getHostDesc(), e.getMessage());
+            LOG.error(e, "Communication error during SSH public key authentication as {0} to {1} failed: {2}", configuration.getUsername(), getHostDesc(), e.getMessage());
             throw new ConnectionFailedException("Communication error during SSH public key authentication as "+configuration.getUsername()+" to "+getHostDesc()+" failed: " + e.getMessage(), e);
         }
     }

--- a/src/main/resources/com/evolveum/polygon/connector/ssh/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ssh/Messages.properties
@@ -17,6 +17,9 @@
 host.display=Host
 host.help=The name or IP address of the SSH server host.
 
+port.display=Port
+port.help=The port number of the SSH server host.
+
 username.display=Username
 username.help=The username to login at the SSH server.
 

--- a/src/main/resources/com/evolveum/polygon/connector/ssh/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/ssh/Messages.properties
@@ -26,6 +26,12 @@ username.help=The username to login at the SSH server.
 password.display=Password
 password.help=The password for the login username.
 
+privateKey.display=Private Key
+privateKey.help=The private key (PKCS #8) for the public key authentication.
+
+passphrase.display=Passphrase
+passphrase.help=The passphrase for the private key.
+
 authenticationScheme.display=Authentication Scheme
 authenticationScheme.help=The authentication scheme defines the login method and can be "password" or "publicKey".
 


### PR DESCRIPTION
I have made the following two improvements:

1. Port can now be configured. It was fixed to 22.
2. The public key authentication function has been improved. Until now, public key authentication could be used by placing the private key in `$HOME/.ssh/id_rsa`. However, private key with passphrase is not supported. Now, the private key (PKCS #8) and passphrase can be set in the connector configuration.

Below is an example configuration:

```
    <additionalConnector>
        <name>ssh</name>
        <connectorRef relation="org:default" type="c:ConnectorType">
            <filter>
                <q:equal>
                    <q:path>c:connectorType</q:path>
                    <q:value>com.evolveum.polygon.connector.ssh.SshConnector</q:value>
                </q:equal>
            </filter>
        </connectorRef>
        <connectorConfiguration xmlns:icfc="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/connector-schema-3">
            <icfc:configurationProperties xmlns:gen199="http://midpoint.evolveum.com/xml/ns/public/connector/icf-1/bundle/com.evolveum.polygon.connector-ssh/com.evolveum.polygon.connector.ssh.SshConnector">
                <gen199:host>sshserver</gen199:host>
                <gen199:port>2222</gen199:port>
                <gen199:username>test</gen199:username>
                <gen199:privateKey>
-----BEGIN OPENSSH PRIVATE KEY-----
b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
...
vZ3VIt7a2dhL0MMZgzqPAAAAEHRlc3RAZXhhbXBsZS5jb20BAgMEBQ==
-----END OPENSSH PRIVATE KEY-----
                </gen199:privateKey>
                <gen199:passphrase>mysecret</gen199:passphrase>
                <gen199:authenticationScheme>publicKey</gen199:authenticationScheme>
                <gen199:argumentStyle>variables-bash</gen199:argumentStyle>
            </icfc:configurationProperties>
            <icfc:resultsHandlerConfiguration>
                <icfc:enableNormalizingResultsHandler>false</icfc:enableNormalizingResultsHandler>
                <icfc:enableFilteredResultsHandler>false</icfc:enableFilteredResultsHandler>
                <icfc:enableAttributesToGetSearchResultsHandler>false</icfc:enableAttributesToGetSearchResultsHandler>
            </icfc:resultsHandlerConfiguration>
        </connectorConfiguration>
    </additionalConnector>
```