### PR TITLE
Fixed NullPointerException when disposing of the connector instance

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/ssh/SshConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/ssh/SshConnector.java
@@ -186,7 +186,7 @@ public class SshConnector implements PoolableConnector, TestOp, ScriptOnResource
             }
             session = null;
         }
-        if (ssh.isConnected()) {
+        if (ssh != null && ssh.isConnected()) {
             LOG.ok("Disconnecting from {0}", getConnectionDesc());
             try {
                 ssh.disconnect();


### PR DESCRIPTION
Connector pool instances are destroyed, for example, when  "Test connection" for a resource is performed. At that time, there is a case where the SSH client is null, and the following NullPointerException is raised.

```
2024-06-26 15:10:00,163 [] [http-nio-8080-exec-6] WARN (org.identityconnectors.framework.impl.api.local.ObjectPool): method: [null, Unexpected error from disposeObject() method: Cannot invoke "net.schmizz.sshj.SSHClient.isConnected()" because "this.ssh" is null] msg:{}
java.lang.NullPointerException: Cannot invoke "net.schmizz.sshj.SSHClient.isConnected()" because "this.ssh" is null
     at com.evolveum.polygon.connector.ssh.SshConnector.disconnect(SshConnector.java:189)
     at com.evolveum.polygon.connector.ssh.SshConnector.dispose(SshConnector.java:203)
     at org.identityconnectors.framework.impl.api.local.ConnectorPoolManager$ConnectorPoolHandler.disposeObject(ConnectorPoolManager.java:165)
     at org.identityconnectors.framework.impl.api.local.ConnectorPoolManager$ConnectorPoolHandler.disposeObject(ConnectorPoolManager.java:86)
     at org.identityconnectors.framework.impl.api.local.ObjectPool.dispose(ObjectPool.java:481)
     at org.identityconnectors.framework.impl.api.local.ObjectPool.disposeAllObjects(ObjectPool.java:419)
     at org.identityconnectors.framework.impl.api.local.ConnectorPoolManager.dispose(ConnectorPoolManager.java:261)
     at org.identityconnectors.framework.impl.api.local.operations.ConnectorOperationalContext.dispose(ConnectorOperationalContext.java:84)
     at org.identityconnectors.framework.impl.api.local.LocalConnectorFacadeImpl.dispose(LocalConnectorFacadeImpl.java:126)
     at com.evolveum.midpoint.provisioning.ucf.impl.connid.ConnectorInstanceConnIdImpl.dispose(ConnectorInstanceConnIdImpl.java:2233)
     at com.evolveum.midpoint.provisioning.impl.resources.ConnectorManager.getOrCreateConnectorInstanceCacheEntry(ConnectorManager.java:247)
     at com.evolveum.midpoint.provisioning.impl.resources.ResourceTestOperation$TestConnectorOperation.instantiateConnector(ResourceTestOperation.java:448)
     at com.evolveum.midpoint.provisioning.impl.resources.ResourceTestOperation$TestConnectorOperation.execute(ResourceTestOperation.java:430)
     at com.evolveum.midpoint.provisioning.impl.resources.ResourceTestOperation.testConnector(ResourceTestOperation.java:283)
     at com.evolveum.midpoint.provisioning.impl.resources.ResourceTestOperation.testAllConnectors(ResourceTestOperation.java:262)
     at com.evolveum.midpoint.provisioning.impl.resources.ResourceTestOperation.lambda$execute$0(ResourceTestOperation.java:201)
     at com.evolveum.midpoint.provisioning.impl.resources.ResourceTestOperation.executeTest(ResourceTestOperation.java:241)
     at com.evolveum.midpoint.provisioning.impl.resources.ResourceTestOperation.execute(ResourceTestOperation.java:199)
     at com.evolveum.midpoint.provisioning.impl.resources.ResourceManager.testResource(ResourceManager.java:241)
     at com.evolveum.midpoint.provisioning.impl.ProvisioningServiceImpl.testResourceInternal(ProvisioningServiceImpl.java:663)
     at com.evolveum.midpoint.provisioning.impl.ProvisioningServiceImpl.testResource(ProvisioningServiceImpl.java:619)
     at com.evolveum.midpoint.provisioning.api.ProvisioningService.testResource(ProvisioningService.java:900)
     at com.evolveum.midpoint.model.impl.controller.ModelController.testResource(ModelController.java:1440)
...
```